### PR TITLE
Fix replaceDebianRepos and MX deb-src substitution

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -158,8 +158,8 @@ void MainWindow::replaceDebianRepos(QString url)
         }
         QTextStream out(&tmpFile);
         out << content;
-        file.close();
-        shell->runAsRoot("mv " + tmpFile.fileName() + " " + filePath);
+        tmpFile.close();
+        shell->runAsRoot("mv -f " + tmpFile.fileName() + " " + filePath);
         shell->runAsRoot("chown root: " + filePath);
         shell->runAsRoot("chmod +r " + filePath);
     }
@@ -470,7 +470,7 @@ bool MainWindow::replaceRepos(const QString &url, bool quiet)
 {
     QString mx_file {"/etc/apt/sources.list.d/mx.list"};
     QString cmd_mx
-        = QString(R"(sed -i -E 's;deb\s(\[.*\]\s)?.*(/mx/repo/|/mx/testrepo);deb \1%1\2;' %2)").arg(url, mx_file);
+        = QString(R"(sed -i -E 's;\s(\[.*\]\s)?.*(/mx/repo/|/mx/testrepo); \1%1\2;' %2)").arg(url, mx_file);
     sources_changed = true;
     if (quiet) {
         return shell->runAsRoot(cmd_mx);


### PR DESCRIPTION
When the new mx-repo-manager was ported to antiX, an issue with "Find fastest Debian mirror" was discovered. When selecting the fastes Debian mirror, the debian.list and debian-stable-updates.list were completely wiped out. The fix is very simple, but took various tests to figure out.

I also included a change for the string substitution performed when switching mirror for the mx.list, which also replaces the mirror for the package sources (if this isn't the desired behavior, please let me know and I will remove this change).

Changes:

- Close tmpFile properly before moving the modified debian list.
- For MX mirror string substitution, make it work for lines containing deb or deb-src.